### PR TITLE
feat: switch to REST endpoint && switch to new `prover.proto`

### DIFF
--- a/proto/prover.proto
+++ b/proto/prover.proto
@@ -11,6 +11,13 @@ service Prover {
     rpc ingest(TableIngest) returns (google.protobuf.Empty) {}
 }
 
+// First value of enum is default value, so if no commitment
+// scheme is specified in ProverQuery, IPA is chosen by default
+enum CommitmentScheme {
+    IPA = 0;
+    DORY = 1;
+}
+
 message ProverContextRange {
     uint64 start = 1;
     repeated uint64 ends = 2;
@@ -24,6 +31,7 @@ message ChosenContextRange {
 message ProverQuery {
     bytes proof_plan = 1;
     map<string, ProverContextRange> query_context = 3;
+    CommitmentScheme commitment_scheme = 4;
 }
 
 message ProverResponse {


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change
It's time to switch to the REST endpoint.
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
- Switch to the REST endpoint.
- Update `prover.proto`.
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code
Yes
If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
