### PR TITLE
feat: fix table range && bump PoSQL version to 0.33.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3289,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "proof-of-sql"
-version = "0.33.5"
+version = "0.33.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e62b4f98ce028082e7dfd89d8e3a5d025caee5dc169f78347b53a79aa73ed0"
+checksum = "34e59ad4f95d1d54eac64589edc90df53201666c2841ad0732461bc6ed1abc36"
 dependencies = [
  "ahash",
  "ark-bls12-381",
@@ -3331,9 +3331,9 @@ dependencies = [
 
 [[package]]
 name = "proof-of-sql-parser"
-version = "0.33.5"
+version = "0.33.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1567a03746bcbcb3772e5363b2c2fc1b5e5c737578365198c70474927264c454"
+checksum = "be6fe34f8fe8942cd7a802ade754de0a7f7a94c0c4b285c877665856c76fcfe6"
 dependencies = [
  "arrayvec 0.7.6",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ dotenv = "0.15"
 flexbuffers = { version = "2.0.0" }
 futures = { version = "0.3.31"}
 postcard = { version = "1.0.10", default-features = false }
-proof-of-sql = { version = "0.33.5"}
-proof-of-sql-parser = { version = "0.33.5" }
+proof-of-sql = { version = "0.33.15" }
+proof-of-sql-parser = { version = "0.33.15" }
 prost = "0.12"
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["serde_derive"] }


### PR DESCRIPTION
# Rationale for this change
The table range in the SDK was fixed as in the original SDK. Now we can obtain the correct range from Substrate hence we fixed it. 
<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?
See above
<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Yes