### PR TITLE
fix: change default SUBSTRATE_NODE_URL to use wss.

### DIFF
--- a/examples/cli/args.rs
+++ b/examples/cli/args.rs
@@ -44,7 +44,7 @@ pub struct SdkArgs {
     #[arg(
         long,
         value_name = "SUBSTRATE_NODE_URL",
-        default_value = "https://rpc.testnet.sxt.network",
+        default_value = "wss://rpc.testnet.sxt.network",
         env = "SUBSTRATE_NODE_URL"
     )]
     pub substrate_node_url: String,


### PR DESCRIPTION
# Rationale for this change

The default `SUBSTRATE_NODE_URL` is wrong.

# What changes are included in this PR?

The `SUBSTRATE_NODE_URL` is fixed.