### PR TITLE
feat: add request to get proof from prover

### DIFF
--- a/chainlink-functions/example/source.js
+++ b/chainlink-functions/example/source.js
@@ -336,7 +336,7 @@ if (!secrets.apiKey) {
 // Set the secrets field to an apiKey that you own for your sxt account.
 
 // Execute the API request using Functions.makeHttpRequest
-const apiResponse = await Functions.makeHttpRequest({
+const authResponse = await Functions.makeHttpRequest({
   url: "https://proxy.api.spaceandtime.dev/auth/apikey",
   method: "POST",
   headers: {
@@ -345,13 +345,17 @@ const apiResponse = await Functions.makeHttpRequest({
   }
 });
 
+if (authResponse.error) {
+  throw new Error("Error querying auth endpoint: " + authResponse.message);
+}
+
 // Extract the access token, truncate it to 256 characters, and return it as an encoded string
-const accessToken = apiResponse.data.accessToken;
+const accessToken = authResponse.data.accessToken;
 
 // TODO: make this not be hardcoded:
 const commitmentKey = "0xca407206ec1ab726b2636c4b145ac28749505e273536fae35330b966dac69e86a4832a125c0464e066dd20add960efb518424c4f434b5320455448455245554d4a9e6f9b8d43f6ad008f8c291929dee201";
 
-const commitmentApiResponse = await Functions.makeHttpRequest({
+const commitmentResponse = await Functions.makeHttpRequest({
   url: "https://rpc.testnet.sxt.network/",
   method: "POST",
   headers: {
@@ -365,10 +369,28 @@ const commitmentApiResponse = await Functions.makeHttpRequest({
   }
 });
 
-let commitment = commitmentApiResponse.data.result.slice(2); // remove the 0x prefix
+if (commitmentResponse.error) {
+  throw new Error("Error querying RPC node: " + commitmentResponse.message);
+}
+
+let commitment = commitmentResponse.data.result.slice(2); // remove the 0x prefix
 const commitments = [new TableRefAndCommitment("ETHEREUM.BLOCKS", commitment)];
 const proverQueryAndQueryExpr = plan_prover_query_dory("SELECT SUM(BLOCK_NUMBER), COUNT(*) FROM ETHEREUM.BLOCKS", commitments);
 const proverQuery = proverQueryAndQueryExpr.prover_query_json;
 const queryExpr = proverQueryAndQueryExpr.query_expr_json;
+
+const proverResponse = await Functions.makeHttpRequest({
+  url: "https://api.spaceandtime.dev/v1/prove",
+  method: "POST",
+  headers: {
+    Authorization: "Bearer " + accessToken,
+    "content-type": "application/json"
+  },
+  data: proverQuery
+});
+
+if (proverResponse.error) {
+  throw new Error("Error querying prover: " + proverResponse.message);
+}
 
 return Functions.encodeString("TODO");


### PR DESCRIPTION
# What changes are included in this PR?

The `source.js` file now queries the prover with the proper access token.

# Are these changes tested?
Yes. The request is authorized, but fails with `Error: InvalidRequest("Unable to deserialize DynProofPlan")`
However, the code in this PR is correct. There is a problem with either the WASM or a prover/client mismatch in versions.