### PR TITLE
ci: create releases on merges to main and preview releases in PRs

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,0 +1,54 @@
+name: Preview Release
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  release-preview:
+    name: Preview Release
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
+          # Pull all previous tags
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Conventional Changelog Action
+        id: conventional-changelog
+        uses: TriPSs/conventional-changelog-action@v5
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          skip-git-pull: true
+          skip-version-file: true
+          git-push: false
+          skip-commit: true
+          skip-tag: true
+          output-file: false
+          skip-on-empty: false # Always create commit
+
+      - name: Format Changelog
+        id: format-changelog
+        run: |
+          echo "${{ steps.conventional-changelog.outputs.changelog }}" > step-changes.md
+          {
+            echo 'changelog<<EOF'
+            find . -type f -name 'step-changes.md' -print0 | xargs -0 sed -E 's/(^|[^!])\[(.*?)\]\(.*?\)/\1\2/g'
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Add PR Comment
+        uses: mshick/add-pr-comment@v2
+        with:
+          message: ${{ steps.format-changelog.outputs.changelog }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: Run Release Manager
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Load Secrets
+        uses: 1password/load-secrets-action@v1
+        with:
+          export-env: true
+        env:
+          OP_CONNECT_HOST: ${{ secrets.OP_CONNECT_HOST }}
+          OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
+          GITHUB_APP_ID: op://op-github-devops/cosmic-agent-labs/app-id
+          GITHUB_PRIVATE_KEY: op://op-github-devops/cosmic-agent-labs/private-key
+
+      - name: Create GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ env.GITHUB_APP_ID }}
+          private-key: ${{ env.GITHUB_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.head_ref }}
+          # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
+          persist-credentials: false
+          # Pull all previous tags
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Conventional Changelog Action
+        id: conventional-changelog
+        uses: TriPSs/conventional-changelog-action@v5
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          skip-git-pull: true
+          skip-version-file: true
+          git-push: false
+          skip-on-empty: false # Always create commit
+
+      - name: Push Conventional Changelog
+        uses: ad-m/github-push-action@master
+        id: push
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          branch: ${{ github.ref }}
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.conventional-changelog.outputs.tag }}
+          body: ${{ steps.conventional-changelog.outputs.changelog }}
+          token: ${{ steps.app-token.outputs.token }}
+          makeLatest: true


### PR DESCRIPTION


# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

This repository currently does not have conventional changelog actions built in.
SxT has standardized on conventional changelog actions so that semver bumping is automatic and github releases are created with every merge. The workflows added here meet this standard.
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->
- preview-release workflow added
- release workflow added
# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
No. These tests do not affect existing functionality.