### PR TITLE
ci: authenticate with default github token in release workflows

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.GH_TOKEN }}
           ref: ${{ github.head_ref }}
           # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
           persist-credentials: false
@@ -29,7 +30,7 @@ jobs:
         id: conventional-changelog
         uses: TriPSs/conventional-changelog-action@v5
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ secrets.GH_TOKEN }}
           skip-git-pull: true
           skip-version-file: true
           git-push: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,27 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Load Secrets
-        uses: 1password/load-secrets-action@v1
-        with:
-          export-env: true
-        env:
-          OP_CONNECT_HOST: ${{ secrets.OP_CONNECT_HOST }}
-          OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
-          GITHUB_APP_ID: op://op-github-devops/cosmic-agent-labs/app-id
-          GITHUB_PRIVATE_KEY: op://op-github-devops/cosmic-agent-labs/private-key
-
-      - name: Create GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.GH_TOKEN }}
           ref: ${{ github.head_ref }}
           # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
           persist-credentials: false
@@ -43,7 +27,7 @@ jobs:
         id: conventional-changelog
         uses: TriPSs/conventional-changelog-action@v5
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ secrets.GH_TOKEN }}
           skip-git-pull: true
           skip-version-file: true
           git-push: false
@@ -53,7 +37,7 @@ jobs:
         uses: ad-m/github-push-action@master
         id: push
         with:
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ secrets.GH_TOKEN }}
           branch: ${{ github.ref }}
 
       - name: Create Release
@@ -61,5 +45,5 @@ jobs:
         with:
           tag: ${{ steps.conventional-changelog.outputs.tag }}
           body: ${{ steps.conventional-changelog.outputs.changelog }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.GH_TOKEN }}
           makeLatest: true


### PR DESCRIPTION

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->
Currently, the release workflows attempt to pull github authentication from 1password. However, this workflow is only intended for use in non-public SxT workflows. Since we do not need access to private SxT information to perform these releases, using the secret github token should suffice for now.
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->
Steps that attempt to use custom github authentication are removed or now use `secrets.GH_TOKEN`.

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
No. These changes do not affect existing functionality.