### PR TITLE
feat: add javascript client and build it into release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,28 @@ jobs:
           github_token: ${{ secrets.GH_TOKEN }}
           branch: ${{ github.ref }}
 
+      - name: Install stable toolchain
+        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
+
+      - name: Install build dependencies
+        run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld protobuf-compiler
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+
+      - name: Build wasm binary
+        run: wasm-pack build --release --target deno --no-typescript crates/proof-of-sql-sdk-wasm
+
+      - name: Build javascript index
+        run: |
+          chmod +x ./node/src/build_index.sh
+          ./node/src/build_index.sh crates/proof-of-sql-sdk-wasm/pkg
+
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.conventional-changelog.outputs.tag }}
           body: ${{ steps.conventional-changelog.outputs.changelog }}
           token: ${{ secrets.GH_TOKEN }}
+          artifacts: "node/src/index.js,node/src/sxt_proof_of_sql_sdk_wasm_bg.wasm"
           makeLatest: true

--- a/node/src/build_index.sh
+++ b/node/src/build_index.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+cat $1/sxt_proof_of_sql_sdk_wasm.js $SCRIPT_DIR/index_tail.js > $SCRIPT_DIR/index.js
+cp $1/sxt_proof_of_sql_sdk_wasm_bg.wasm $SCRIPT_DIR

--- a/node/src/index_tail.js
+++ b/node/src/index_tail.js
@@ -1,0 +1,104 @@
+export class SxTClient {
+  constructor(proverRootURL, authRootURL, substrateNodeURL, sxtApiKey) {
+    this.proverRootURL = proverRootURL;
+    this.authRootURL = authRootURL;
+    this.substrateNodeURL = substrateNodeURL;
+    this.sxtApiKey = sxtApiKey;
+  }
+
+  async #getAccessToken() {
+    // Ensure the API key is available
+    if (!this.sxtApiKey) {
+      throw Error("API Key Not Found");
+    }
+    const authResponse = await postHttpRequest({
+      url: this.authRootURL,
+      headers: {
+        apikey: this.sxtApiKey,
+        "Content-Type": "application/json",
+      },
+    });
+    if (!authResponse.ok) {
+      throw new Error(
+        `Error querying auth endpoint: ${authResponse.status}: ${authResponse.statusText}`,
+      );
+    }
+    return authResponse.json();
+  }
+  async #getCommitment(commitmentKey) {
+    const commitmentResponse = await postHttpRequest({
+      url: this.substrateNodeURL,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      data: {
+        id: 1,
+        jsonrpc: "2.0",
+        method: "state_getStorage",
+        params: [commitmentKey],
+      },
+    });
+
+    if (!commitmentResponse.ok) {
+      throw new Error(
+        `Error querying RPC node: ${commitmentResponse.status}: ${commitmentResponse.statusText}`,
+      );
+    }
+
+    return commitmentResponse.json();
+  }
+  async #getProof(accessToken, proverQuery) {
+    const proverResponse = await postHttpRequest({
+      url: this.proverRootURL,
+      headers: {
+        Authorization: "Bearer " + accessToken,
+        "content-type": "application/json",
+      },
+      data: proverQuery,
+    });
+
+    if (!proverResponse.ok) {
+      throw new Error(
+        `Error querying prover: ${proverResponse.status}: ${proverResponse.statusText}`,
+      );
+    }
+
+    return proverResponse.json();
+  }
+
+  async queryAndVerify(queryString, table) {
+    const commitmentKey = "0x" + commitment_storage_key_dory(table);
+    const authResponse = await this.#getAccessToken();
+    const accessToken = authResponse.accessToken;
+    const commitmentResponse = await this.#getCommitment(commitmentKey);
+    const commitment = commitmentResponse.result.slice(2); // remove the 0x prefix
+
+    let commitments = [new TableRefAndCommitment(table, commitment)];
+    const plannedProverQuery = plan_prover_query_dory(queryString, commitments);
+    const proverQuery = plannedProverQuery.prover_query_json;
+    const queryExpr = plannedProverQuery.query_expr_json;
+    commitments = plannedProverQuery.commitments;
+
+    const proverResponseJson = await this.#getProof(accessToken, proverQuery);
+
+    const result = verify_prover_response_dory(
+      proverResponseJson,
+      queryExpr,
+      commitments,
+    );
+    return result;
+  }
+}
+
+async function postHttpRequest({ url, headers = {}, data = null }) {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), 3000);
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: data ? JSON.stringify(data) : undefined,
+    signal: controller.signal,
+  });
+  clearTimeout(id);
+  return response;
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.81.0"


### PR DESCRIPTION
# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->
A javascript port of the rust sdk client is convenient for use in javascript environments like chainlink. This adds such a port in index_tail.js, which can be attached to the index.js produced by wasm-pack using the provided build_index.sh script. It also adds steps to the release CI for adding the resulting build as a release artifact in this repository.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->
- feat: add javascript client and script to attach it to wasm-pack
- feat: set rust toolchain channel to 1.81
- ci: build wasm and javascript index as artifacts of release
# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
We have done testing with chainlink using this build process, just not within the CI. The CI release process will only be tested by merging this.