### PR TITLE
ci: publish node directory as npm package in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,12 +33,36 @@ jobs:
           git-push: false
           skip-on-empty: false # Always create commit
 
+      - name: Bump package.json Version
+        working-directory: ./node
+        run: |
+          TAG=${{ steps.conventional-changelog.outputs.tag }}
+          VERSION=${TAG#v}
+          echo "Bumping npm package version to $VERSION"
+          npm version $VERSION --no-git-tag-version
+
+      - name: Commit package.json Version
+        working-directory: ./node
+        run: |
+          TAG=${{ steps.conventional-changelog.outputs.tag }}
+          VERSION=${TAG#v}
+          git add package.json
+          git commit -m "chore(release): bump npm package version to $VERSION"
+
       - name: Push Conventional Changelog
         uses: ad-m/github-push-action@master
         id: push
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           branch: ${{ github.ref }}
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.conventional-changelog.outputs.tag }}
+          body: ${{ steps.conventional-changelog.outputs.changelog }}
+          token: ${{ secrets.GH_TOKEN }}
+          makeLatest: true
 
       - name: Install stable toolchain
         run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
@@ -57,10 +81,16 @@ jobs:
           chmod +x ./node/src/build_index.sh
           ./node/src/build_index.sh crates/proof-of-sql-sdk-wasm/pkg
 
-      - name: Create Release
-        uses: ncipollo/release-action@v1
+      - name: Set Up Node.js
+        uses: actions/setup-node@v3
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         with:
-          tag: ${{ steps.conventional-changelog.outputs.tag }}
-          body: ${{ steps.conventional-changelog.outputs.changelog }}
-          token: ${{ secrets.GH_TOKEN }}
-          makeLatest: true
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org/'
+          scope: '@spaceandtimelabs'
+
+      - name: Publish to npm
+        working-directory: ./node
+        run: |
+          npm publish --access public --non-interactive


### PR DESCRIPTION


# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->
For the greatest user experience in chainlink functions and javascript in general, the javascript port of the sdk client should be accessible in NPM. This adds various steps to the release CI to enable this automation.

Depends on #41 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->
Steps added to release CI to manage package.json and publish to npm.

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
No, they will only be tested by merging this PR unfortunately.