### PR TITLE
feat: support querying at particular blocks

### DIFF
--- a/crates/proof-of-sql-sdk/examples/cli/args.rs
+++ b/crates/proof-of-sql-sdk/examples/cli/args.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use subxt::utils::H256;
 use sxt_proof_of_sql_sdk::{PostprocessingLevel, SxTClient};
 
 /// Struct to define and parse command-line arguments for Proof of SQL Client.
@@ -67,6 +68,10 @@ pub struct SdkArgs {
         help = "Table reference in format schema.table"
     )]
     pub table_ref: String,
+
+    /// SxT chain block hash to perform the query at.
+    #[arg(long)]
+    pub block_hash: Option<H256>,
 
     /// Path to the verifier setup binary file
     ///

--- a/crates/proof-of-sql-sdk/examples/cli/main.rs
+++ b/crates/proof-of-sql-sdk/examples/cli/main.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
 
     // Execute the query and verify the result
     let result = client
-        .query_and_verify(&args.query, &args.table_ref)
+        .query_and_verify(&args.query, &args.table_ref, args.block_hash)
         .await?;
 
     // Print the result of the query

--- a/crates/proof-of-sql-sdk/examples/count-ethereum-core/main.rs
+++ b/crates/proof-of-sql-sdk/examples/count-ethereum-core/main.rs
@@ -28,7 +28,7 @@ async fn count_table(
     let uppercased_table_ref = table_ref.to_uppercase();
     let query = format!("SELECT COUNT(*) FROM {uppercased_table_ref}");
     let table = client
-        .query_and_verify(&query, &uppercased_table_ref)
+        .query_and_verify(&query, &uppercased_table_ref, None)
         .await?;
     assert_eq!(table.num_columns(), 1);
     assert_eq!(table.num_rows(), 1);

--- a/node/src/index_tail.js
+++ b/node/src/index_tail.js
@@ -25,7 +25,9 @@ export class SxTClient {
     }
     return authResponse.json();
   }
-  async #getCommitment(commitmentKey) {
+  async #getCommitment(commitmentKey, blockHash = null) {
+    const params = blockHash ? [commitmentKey, blockHash] : [commitmentKey]
+
     const commitmentResponse = await postHttpRequest({
       url: this.substrateNodeURL,
       headers: {
@@ -35,7 +37,7 @@ export class SxTClient {
         id: 1,
         jsonrpc: "2.0",
         method: "state_getStorage",
-        params: [commitmentKey],
+        params,
       },
     });
 
@@ -66,11 +68,11 @@ export class SxTClient {
     return proverResponse.json();
   }
 
-  async queryAndVerify(queryString, table) {
+  async queryAndVerify(queryString, table, blockHash = null) {
     const commitmentKey = "0x" + commitment_storage_key_dory(table);
     const authResponse = await this.#getAccessToken();
     const accessToken = authResponse.accessToken;
-    const commitmentResponse = await this.#getCommitment(commitmentKey);
+    const commitmentResponse = await this.#getCommitment(commitmentKey, blockHash);
     const commitment = commitmentResponse.result.slice(2); // remove the 0x prefix
 
     let commitments = [new TableRefAndCommitment(table, commitment)];


### PR DESCRIPTION


# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->
Currently, both the rust and javascript clients perform queries at the latest block. We want to be able to perform queries at older blocks too. This is especially important for the chainlink use case, as chainlink's DON will perform the same query multiple times, expecting the same results from each run. To this end, this changes both clients and their underlying functions to accept an optional block hash.
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->
- rust client updated to accept an optional block ref with queries
- rust CLI updated to accept an optional block hash
- javascript client updated to accept an optional block hash
# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
Only localy, no automated tests as these are difficult with the current stateful structure of the affected code.