### PR TITLE
fix: install active toolchain in CI after rustup 1.28 upgrade

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -33,7 +33,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.toml') }}
       - name: Install stable toolchain
-        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
+        run: curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env && rustup toolchain install
       - name: Install Dependencies
         run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld protobuf-compiler
       - name: Run cargo check (default features and packages)
@@ -59,7 +59,7 @@ jobs:
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.toml') }}
       - name: Install stable toolchain
         run: |
-          curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
+          curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env && rustup toolchain install
           rustup component add clippy
       - name: Install Dependencies
         run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld protobuf-compiler
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install stable toolchain
         run: |
-          curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env
+          curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env && rustup toolchain install
           rustup component add rustfmt
       - name: Run cargo fmt
         run: cargo fmt --all -- --config imports_granularity=Crate,group_imports=One --check
@@ -90,8 +90,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install nightly toolchain
         run: |
-          curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env && rustup default nightly
-          cargo install cargo-udeps --locked
+          curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal && source ~/.cargo/env && rustup toolchain install nightly
+          cargo +nightly install cargo-udeps --locked
       - name: Install Dependencies
         run: export DEBIAN_FRONTEND=non-interactive && sudo apt-get update && sudo apt-get install -y clang lld protobuf-compiler
       - name: Run cargo udeps


### PR DESCRIPTION
# Rationale for this change
In previous versions of rustup, the active toolchain (defined by rust-toolchain.toml) would automatically be installed by cargo. Now, this needs to be performed as a separate command. This change copes with the breaking rustup behavior in CI.

# What changes are included in this PR?
- Install active rustup toolchain as separate command in CI

# Are these changes tested?
No, these changes do not affect functionality.
