### PR TITLE
fix: coerce input table refs to lowercase

### DIFF
--- a/crates/proof-of-sql-sdk-local/src/prover_query.rs
+++ b/crates/proof-of-sql-sdk-local/src/prover_query.rs
@@ -54,7 +54,7 @@ pub fn plan_prover_query_dory(
         .iter()
         .map(|(table_ref, commitment)| {
             (
-                table_ref.to_string().to_uppercase(),
+                table_ref.to_string(),
                 ProverContextRange {
                     start: commitment.range().start as u64,
                     ends: vec![commitment.range().end as u64],

--- a/crates/proof-of-sql-sdk/src/client.rs
+++ b/crates/proof-of-sql-sdk/src/client.rs
@@ -90,7 +90,7 @@ impl SxTClient {
         block_ref: Option<<SxtConfig as Config>::Hash>,
     ) -> Result<OwnedTable<DoryScalar>, Box<dyn core::error::Error>> {
         // Parse table into `TableRef` struct
-        let table_ref = table.try_into()?;
+        let table_ref = table.to_lowercase().as_str().try_into()?;
 
         // Load verifier setup
         let verifier_setup_path = Path::new(&self.verifier_setup);


### PR DESCRIPTION
# Rationale for this change
Proof-of-sql has been gradually switching to sqlparser for its parsing and sql typing. One consequence of this change is that TableRefs are no longer case insensitive. Previously, constructing TableRefs would coerce the identifier to lowercase. To preserve previous behavior, this now needs to be done manually.

# What changes are included in this PR?
TableRefs are converted to lowercase at the start of the client code.

# Are these changes tested?
No. This repository does not have great test coverage in general, but this is not the PR to add it.
