### PR TITLE
fix: upgrade to proof-of-sql 0.75.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "num-traits",
  "serde",
@@ -3134,9 +3134,9 @@ dependencies = [
 
 [[package]]
 name = "proof-of-sql"
-version = "0.73.3"
+version = "0.75.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b725f6b8a292e1184ac626643685a60058b7bbccc98be0b047e2648c8058b7"
+checksum = "59345f630953114264653d93aa26e38d426269e0b702bb13f95e39b3fb117184"
 dependencies = [
  "ahash",
  "ark-bls12-381",
@@ -3177,9 +3177,9 @@ dependencies = [
 
 [[package]]
 name = "proof-of-sql-parser"
-version = "0.73.3"
+version = "0.75.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbb4d6848d1eddf84f81656f7a3658e19632b9678704e35208d926f1faca5c6"
+checksum = "1ce21af1c143dcf3845f8cdedfa5d63d198cb72267c15d1fcdb82dadaabb27f6"
 dependencies = [
  "arrayvec 0.7.6",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ log = "0.4.22"
 indexmap = "2.6.0"
 parity-scale-codec = { version = "3.7.0", default-features = false }
 postcard = { version = "1.0.10", default-features = false }
-proof-of-sql = { version = "0.73.1", default-features = false }
-proof-of-sql-parser = { version = "0.73.1", default-features = false }
+proof-of-sql = { version = "0.75.2", default-features = false }
+proof-of-sql-parser = { version = "0.75.2", default-features = false }
 prost = "0.12"
 prost-build = "0.12"
 reqwest = { version = "0.12", features = ["json"] }


### PR DESCRIPTION
# Rationale for this change
proof-of-sql 0.73.1 was unexpectedly limited in its VarBinary support. In particular, it did not implement arrow conversions for the VarBinary column type. These conversions have since been added and released in proof-of-sql.

This may not be strictly necessary for the SDK, but it is an easy update to make, and will ensure that the proof-of-sql version is in sync between the SDK and the prover service.

# What changes are included in this PR?
- proof-of-sql is upgraded to 0.75.2

# Are these changes tested?
These changes should not affect existing functionality.
