### PR TITLE
feat: upgrade proof-of-sql to 0.76.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3134,9 +3134,9 @@ dependencies = [
 
 [[package]]
 name = "proof-of-sql"
-version = "0.75.2"
+version = "0.76.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59345f630953114264653d93aa26e38d426269e0b702bb13f95e39b3fb117184"
+checksum = "d34bad706431f13b7b130ea5ba21bea56c70e01074a8ba2b304149618ce63d6c"
 dependencies = [
  "ahash",
  "ark-bls12-381",
@@ -3177,9 +3177,9 @@ dependencies = [
 
 [[package]]
 name = "proof-of-sql-parser"
-version = "0.75.2"
+version = "0.76.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce21af1c143dcf3845f8cdedfa5d63d198cb72267c15d1fcdb82dadaabb27f6"
+checksum = "ca509353e9eb1106224ded388084570e9037edecbbdbd587a84e0d86c06907cc"
 dependencies = [
  "arrayvec 0.7.6",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ log = "0.4.22"
 indexmap = "2.6.0"
 parity-scale-codec = { version = "3.7.0", default-features = false }
 postcard = { version = "1.0.10", default-features = false }
-proof-of-sql = { version = "0.75.2", default-features = false }
-proof-of-sql-parser = { version = "0.75.2", default-features = false }
+proof-of-sql = { version = "0.76.11", default-features = false }
+proof-of-sql-parser = { version = "0.76.11", default-features = false }
 prost = "0.12"
 prost-build = "0.12"
 reqwest = { version = "0.12", features = ["json"] }


### PR DESCRIPTION
# Rationale for this change
Proof-of-sql has recently received improved VarBinary column support. In particular, it now supports equality and parsing literals. This change pulls these features into the SDK so that it can create ProvableAsts and perform verification accordingly.

# What changes are included in this PR?
Proof-of-sql dependencies have been upgraded to 0.76.11

# Are these changes tested?
No. This repository needs greater test coverage in general, but this is not the PR to add it.
