### PR TITLE
docs: add reference to SxT API key in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ The Space and Time Proof of SQL SDK is a Rust crate designed to simplify the pro
 
 ## Installation
 
+Make sure you have the following installed:
+- [protoc](https://protobuf.dev/installation/)
+- OpenSSL
+
+On Debian-based Linux distros you can do the following to install all of them
+```bash
+apt update && apt upgrade -y
+apt install -y protobuf-compiler pkg-config libssl-dev
+```
+
 Add the following to your `Cargo.toml`:
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ To run the provided example that counts entries in the Ethereum core table:
 
 ```bash
 
-cargo run --example cli -- -q "select * from ethereum.blocks" --table-ref "ethereum.blocks"
+cargo run --example cli -- -q "select * from ethereum.blocks" --table-ref "ethereum.blocks" --sxt-api-key "your_sxt_api_key"
 ```
+Alternatively you may set your SxT API key via the environment variable `SXT_API_KEY`.
 
 ### Basic Usage in Code
 


### PR DESCRIPTION
# Rationale for this change
- add reference to SxT API key in `README.md`
- add installation requirements