### PR TITLE
feat: update proto files and bump `proof-of-sql` to 0.86.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,9 +3135,9 @@ dependencies = [
 
 [[package]]
 name = "proof-of-sql"
-version = "0.76.15"
+version = "0.85.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34bad706431f13b7b130ea5ba21bea56c70e01074a8ba2b304149618ce63d6c"
+checksum = "73f0f48b81cf39d2c81e70955cbfb7e66a1f8ab1fdbd3d8316340358ba23fb75"
 dependencies = [
  "ahash",
  "ark-bls12-381",
@@ -3178,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "proof-of-sql-parser"
-version = "0.76.15"
+version = "0.85.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca509353e9eb1106224ded388084570e9037edecbbdbd587a84e0d86c06907cc"
+checksum = "25d7c0a0873effea19d1c70efca046cc896bb7f1734b6ae1597051941a8d8e25"
 dependencies = [
  "arrayvec 0.7.6",
  "bigdecimal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,9 +3135,9 @@ dependencies = [
 
 [[package]]
 name = "proof-of-sql"
-version = "0.85.2"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f0f48b81cf39d2c81e70955cbfb7e66a1f8ab1fdbd3d8316340358ba23fb75"
+checksum = "5398fba84871b94f87e2fb5cf6d4a22e7e0347abcb63e36af7dd509da4a6b91a"
 dependencies = [
  "ahash",
  "ark-bls12-381",
@@ -3178,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "proof-of-sql-parser"
-version = "0.85.2"
+version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d7c0a0873effea19d1c70efca046cc896bb7f1734b6ae1597051941a8d8e25"
+checksum = "4d702bd28207f036db216824c39ccae00257db4f0ce8a09d45091d2a03a14764"
 dependencies = [
  "arrayvec 0.7.6",
  "bigdecimal",
@@ -4471,7 +4471,9 @@ dependencies = [
  "proof-of-sql",
  "proof-of-sql-parser",
  "prost",
+ "prost-types",
  "serde",
+ "serde_json",
  "sha3",
  "snafu",
  "sqlparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ lazy_static = { version = "1.5.0" }
 log = "0.4.22"
 indexmap = "2.6.0"
 parity-scale-codec = { version = "3.7.0", default-features = false }
-proof-of-sql = { version = "0.76.11", default-features = false }
-proof-of-sql-parser = { version = "0.76.11", default-features = false }
+proof-of-sql = { version = "0.85.2", default-features = false }
+proof-of-sql-parser = { version = "0.85.2", default-features = false }
 prost = "0.12"
 prost-build = "0.12"
 reqwest = { version = "0.12", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,11 @@ lazy_static = { version = "1.5.0" }
 log = "0.4.22"
 indexmap = "2.6.0"
 parity-scale-codec = { version = "3.7.0", default-features = false }
-proof-of-sql = { version = "0.85.2", default-features = false }
-proof-of-sql-parser = { version = "0.85.2", default-features = false }
+proof-of-sql = { version = "0.86.0", default-features = false }
+proof-of-sql-parser = { version = "0.86.0", default-features = false }
 prost = "0.12"
 prost-build = "0.12"
+prost-types = "0.12"
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["serde_derive"] }
 serde_json = "1.0"

--- a/crates/proof-of-sql-sdk-local/Cargo.toml
+++ b/crates/proof-of-sql-sdk-local/Cargo.toml
@@ -10,6 +10,7 @@ bincode = { workspace = true, default-features = false, features = ["serde", "al
 proof-of-sql = { workspace = true }
 proof-of-sql-parser = { workspace = true }
 prost = { workspace = true }
+prost-types = { workspace = true }
 tonic = { workspace = true, features = ["codegen", "prost"] }
 serde = { workspace = true }
 snafu = { workspace = true }
@@ -20,6 +21,9 @@ sha3 = { workspace = true }
 
 [build-dependencies]
 tonic-build = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
 
 [features]
 default = ["native", "prover-client"]

--- a/crates/proof-of-sql-sdk-local/build.rs
+++ b/crates/proof-of-sql-sdk-local/build.rs
@@ -12,6 +12,14 @@ fn main() {
 
     tonic_build::configure()
         .type_attribute(".", "#[derive(serde::Serialize,serde::Deserialize)]")
+        .field_attribute(
+            "sxt.core.ProverResponse.exec_time",
+            "#[serde(default, serialize_with = \"crate::duration_serde::serialize\", deserialize_with = \"crate::duration_serde::deserialize\")]",
+        )
+        .field_attribute(
+            "sxt.core.ProofAndResultForCommitments.exec_time",
+            "#[serde(default, serialize_with = \"crate::duration_serde::serialize\", deserialize_with = \"crate::duration_serde::deserialize\")]",
+        )
         .type_attribute(".", "#[allow(clippy::all)]")
         .build_client(cfg!(feature = "prover-client"))
         .build_server(false)

--- a/crates/proof-of-sql-sdk-local/proto/prover.proto
+++ b/crates/proof-of-sql-sdk-local/proto/prover.proto
@@ -4,10 +4,12 @@ package sxt.core;
 
 import "ingest.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/duration.proto";
 
 // Interface exported by the server
 service Prover {
     rpc queryWithProof(ProverQuery) returns (ProverResponse) {}
+    rpc queryWithProofForCommitments(ProverQueryForCommitments) returns (ProofAndResultForCommitments) {}
     rpc ingest(TableIngest) returns (google.protobuf.Empty) {}
 }
 
@@ -16,6 +18,7 @@ service Prover {
 enum CommitmentScheme {
     IPA = 0;
     DYNAMIC_DORY = 1;
+    HYPER_KZG = 2;
 }
 
 message ProverContextRange {
@@ -35,6 +38,20 @@ message ProverQuery {
 }
 
 message ProverResponse {
-    bytes verifiable_result = 1;
+    bytes proof = 1;
     map<string, ChosenContextRange> chosen_context = 2;
+    google.protobuf.Duration exec_time = 3;
+    bytes result = 4;
+}
+
+message ProverQueryForCommitments {
+    bytes proof_plan = 1;
+    map<string, bytes> query_commitments = 2;
+    CommitmentScheme commitment_scheme = 3;
+}
+
+message ProofAndResultForCommitments {
+    bytes proof = 1;
+    google.protobuf.Duration exec_time = 2;
+    bytes result = 3;
 }

--- a/crates/proof-of-sql-sdk-local/src/duration_serde.rs
+++ b/crates/proof-of-sql-sdk-local/src/duration_serde.rs
@@ -1,0 +1,75 @@
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+
+/// Custom serialization for `prost_types::Duration` for protobuf compatibility.
+pub fn serialize<S>(
+    duration: &Option<prost_types::Duration>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match duration {
+        Some(d) => d.to_string().serialize(serializer),
+        None => serializer.serialize_none(),
+    }
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<prost_types::Duration>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Expect either `null` or a string
+    let maybe_string = Option::<String>::deserialize(deserializer)?;
+    match maybe_string {
+        Some(s) => {
+            // Attempt to parse the string into `prost_types::Duration`
+            let duration = s
+                .parse::<prost_types::Duration>()
+                .map_err(D::Error::custom)?;
+            Ok(Some(duration))
+        }
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost_types::Duration;
+
+    #[derive(Deserialize, Serialize)]
+    struct TestDuration {
+        #[serde(serialize_with = "serialize", deserialize_with = "deserialize")]
+        duration: Option<Duration>,
+    }
+
+    #[test]
+    fn test_serialize_and_deserialize_some_duration() {
+        let td = TestDuration {
+            duration: Some(Duration {
+                seconds: 42,
+                nanos: 123,
+            }),
+        };
+        let json = serde_json::to_string(&td).unwrap();
+        assert!(json.contains("42"));
+        assert!(json.contains("123"));
+        let roundtripped: Duration = serde_json::from_str::<TestDuration>(&json)
+            .unwrap()
+            .duration
+            .unwrap();
+        assert_eq!(roundtripped.seconds, 42);
+        assert_eq!(roundtripped.nanos, 123);
+    }
+
+    #[test]
+    fn test_serialize_and_deserialize_no_duration() {
+        let td = TestDuration { duration: None };
+        let json = serde_json::to_string(&td).unwrap();
+        assert_eq!(json, r#"{"duration":null}"#);
+        assert!(serde_json::from_str::<TestDuration>(&json)
+            .unwrap()
+            .duration
+            .is_none());
+    }
+}

--- a/crates/proof-of-sql-sdk-local/src/lib.rs
+++ b/crates/proof-of-sql-sdk-local/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 
+mod duration_serde;
 /// subxt-generated code for interacting with the sxt-chain runtime
 pub mod sxt_chain_runtime;
 


### PR DESCRIPTION
# Rationale for this change
We need to make sure proto files across Proof of SQL remain in sync. Hence I updated the proto files and fixed the code to align with the new ones.