### PR TITLE
fix: workaround difference in casing between QueryExpr and storage

### DIFF
--- a/crates/proof-of-sql-sdk/src/client.rs
+++ b/crates/proof-of-sql-sdk/src/client.rs
@@ -90,7 +90,7 @@ impl SxTClient {
         block_ref: Option<<SxtConfig as Config>::Hash>,
     ) -> Result<OwnedTable<DoryScalar>, Box<dyn core::error::Error>> {
         // Parse table into `TableRef` struct
-        let table_ref = table.to_lowercase().as_str().try_into()?;
+        let table_ref = table.to_uppercase().as_str().try_into()?;
 
         // Load verifier setup
         let verifier_setup_path = Path::new(&self.verifier_setup);


### PR DESCRIPTION
# Rationale for this change
It seems that QueryExpr::try_new is probably coercing the table refs and column refs to lowercase. This is an issue for using the query commitments provided by substrate as a SchemaAccessor, as all of substrate's table identifiers and column identifiers are coerced to uppercase.

# What changes are included in this PR?
This PR attempts to work around the issue by implementing a SchemaAccessor that coerces to uppercase before querying an inner SchemaAccessor.
