### PR TITLE
feat: bump `proof-of-sql` to `0.91.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,9 +3135,9 @@ dependencies = [
 
 [[package]]
 name = "proof-of-sql"
-version = "0.86.0"
+version = "0.91.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5398fba84871b94f87e2fb5cf6d4a22e7e0347abcb63e36af7dd509da4a6b91a"
+checksum = "51612d5ba8d96d6f0756bb563ef3c315f5860176d39cded4fcf3730ef5b77ce0"
 dependencies = [
  "ahash",
  "ark-bls12-381",
@@ -3178,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "proof-of-sql-parser"
-version = "0.86.0"
+version = "0.91.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d702bd28207f036db216824c39ccae00257db4f0ce8a09d45091d2a03a14764"
+checksum = "34b1b2bc22c7e86756a39910dc2d73806a0d86a161a5876f4e12f5f2c51f0b0f"
 dependencies = [
  "arrayvec 0.7.6",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ lazy_static = { version = "1.5.0" }
 log = "0.4.22"
 indexmap = "2.6.0"
 parity-scale-codec = { version = "3.7.0", default-features = false }
-proof-of-sql = { version = "0.86.0", default-features = false }
-proof-of-sql-parser = { version = "0.86.0", default-features = false }
+proof-of-sql = { version = "0.91.1", default-features = false }
+proof-of-sql-parser = { version = "0.91.1", default-features = false }
 prost = "0.12"
 prost-build = "0.12"
 prost-types = "0.12"

--- a/crates/proof-of-sql-sdk-local/src/verify.rs
+++ b/crates/proof-of-sql-sdk-local/src/verify.rs
@@ -2,7 +2,7 @@ use crate::{prover::ProverResponse, uppercase_accessor::UppercaseAccessor};
 use proof_of_sql::{
     base::{
         commitment::CommitmentEvaluationProof,
-        database::{CommitmentAccessor, OwnedTable},
+        database::{CommitmentAccessor, LiteralValue, OwnedTable},
     },
     sql::{
         parse::QueryExpr,
@@ -36,6 +36,7 @@ impl From<bincode::error::DecodeError> for VerifyProverResponseError {
 pub fn verify_prover_response<'de, 's, CP: CommitmentEvaluationProof + Deserialize<'de>>(
     prover_response: &'de ProverResponse,
     query_expr: &QueryExpr,
+    params: &[LiteralValue],
     accessor: &impl CommitmentAccessor<CP::Commitment>,
     verifier_setup: &CP::VerifierPublicSetup<'s>,
 ) -> Result<OwnedTable<CP::Scalar>, VerifyProverResponseError> {
@@ -61,6 +62,7 @@ pub fn verify_prover_response<'de, 's, CP: CommitmentEvaluationProof + Deseriali
         &accessor,
         result.clone(),
         verifier_setup,
+        params,
     )?;
     Ok(result)
 }

--- a/crates/proof-of-sql-sdk-wasm/src/lib.rs
+++ b/crates/proof-of-sql-sdk-wasm/src/lib.rs
@@ -184,6 +184,7 @@ pub fn verify_prover_response_dory(
         sxt_proof_of_sql_sdk_local::verify_prover_response::<DynamicDoryEvaluationProof>(
             &prover_response,
             &query_expr,
+            &[],
             &query_commitments,
             &&*VERIFIER_SETUP,
         )

--- a/crates/proof-of-sql-sdk/src/client.rs
+++ b/crates/proof-of-sql-sdk/src/client.rs
@@ -133,6 +133,7 @@ impl SxTClient {
         let verified_table_result = verify_prover_response::<DynamicDoryEvaluationProof>(
             &prover_response,
             &query_expr,
+            &[],
             &accessor,
             &&verifier_setup,
         )?;


### PR DESCRIPTION
# Rationale for this change
Latest version of `proof-of-sql` allows parameterized queries. We enable them in `proof-of-sql-sdk-local` but not the two downstream crates in this repo yet since we need to consider what the APIs should look like.