### PR TITLE
feat: parse table refs out of query text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4253,6 +4253,18 @@ checksum = "f7bbffee862a796d67959a89859d6b1046bb5016d63e23835ad0da182777bbe0"
 dependencies = [
  "log",
  "serde",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -4456,6 +4468,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "snafu",
+ "sqlparser",
  "subxt",
  "sxt-proof-of-sql-sdk-local",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ cargo run --example cli -- -q "select * from ethereum.blocks" --sxt-api-key "you
 ```
 Alternatively you may set your SxT API key via the environment variable `SXT_API_KEY`.
 
+For more options, you can view the help text with:
+```bash
+cargo run --example cli -- --help
+```
+
 ### Basic Usage in Code
 
 Here's how you can use the `SxTClient` in your Rust application:

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ cargo build
 To run the provided example that counts entries in the Ethereum core table:
 
 ```bash
-
-cargo run --example cli -- -q "select * from ethereum.blocks" --table-ref "ethereum.blocks" --sxt-api-key "your_sxt_api_key"
+cargo run --example cli -- -q "select * from ethereum.blocks" --sxt-api-key "your_sxt_api_key"
 ```
 Alternatively you may set your SxT API key via the environment variable `SXT_API_KEY`.
 

--- a/crates/proof-of-sql-sdk-local/src/prover_query.rs
+++ b/crates/proof-of-sql-sdk-local/src/prover_query.rs
@@ -82,7 +82,6 @@ pub fn plan_prover_query_dory(
     query: &str,
     commitments: &QueryCommitments<DynamicDoryCommitment>,
 ) -> Result<(ProverQuery, QueryExpr), PlanProverQueryError> {
-    dbg!(&commitments);
     let query_expr: QueryExpr = QueryExpr::try_new(
         query.parse()?,
         Ident::new(DEFAULT_SCHEMA),

--- a/crates/proof-of-sql-sdk/Cargo.toml
+++ b/crates/proof-of-sql-sdk/Cargo.toml
@@ -17,6 +17,7 @@ proof-of-sql = { workspace = true, features = ["std"] }
 proof-of-sql-parser = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde_json.workspace = true
+sqlparser = { workspace = true, features = ["visitor", "std"] }
 subxt = { workspace = true, features = ["jsonrpsee"] }
 sxt-proof-of-sql-sdk-local = { workspace = true, features = ["native", "prover-client"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/proof-of-sql-sdk/examples/cli/args.rs
+++ b/crates/proof-of-sql-sdk/examples/cli/args.rs
@@ -61,14 +61,6 @@ pub struct SdkArgs {
     #[arg(short, long, value_name = "QUERY", help = "SQL query to run")]
     pub query: String,
 
-    /// Table reference for the SQL query in the format `schema.table`
-    #[arg(
-        long,
-        value_name = "TABLE_REF",
-        help = "Table reference in format schema.table"
-    )]
-    pub table_ref: String,
-
     /// SxT chain block hash to perform the query at.
     #[arg(long)]
     pub block_hash: Option<H256>,

--- a/crates/proof-of-sql-sdk/examples/cli/main.rs
+++ b/crates/proof-of-sql-sdk/examples/cli/main.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
 
     // Execute the query and verify the result
     let result = client
-        .query_and_verify(&args.query, &args.table_ref, args.block_hash)
+        .query_and_verify(&args.query, args.block_hash)
         .await?;
 
     // Print the result of the query

--- a/crates/proof-of-sql-sdk/examples/count-ethereum-core/main.rs
+++ b/crates/proof-of-sql-sdk/examples/count-ethereum-core/main.rs
@@ -27,9 +27,7 @@ async fn count_table(
 ) -> Result<i64, Box<dyn core::error::Error>> {
     let uppercased_table_ref = table_ref.to_uppercase();
     let query = format!("SELECT COUNT(*) FROM {uppercased_table_ref}");
-    let table = client
-        .query_and_verify(&query, &uppercased_table_ref, None)
-        .await?;
+    let table = client.query_and_verify(&query, None).await?;
     assert_eq!(table.num_columns(), 1);
     assert_eq!(table.num_rows(), 1);
 


### PR DESCRIPTION
# Rationale for this change
Currently there's a bit of redundancy in client input. The query_and_verify function accepts the table ref and query text in separate parameters. However, the table ref should always just be contained in the query text. This change makes it so the table-ref is parsed out of the query text, and technically is forward-compatible with multi-table queries.

# What changes are included in this PR?
- **feat: parse table refs out of query text**
- **docs: mention how to get help text for CLI in README.md**
