### PR TITLE
feat: implement more Accessors for UppercaseAccessor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4485,6 +4485,7 @@ dependencies = [
  "proof-of-sql-parser",
  "prost",
  "prost-types",
+ "rand",
  "serde",
  "serde_json",
  "sha3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ proof-of-sql-parser = { version = "0.86.0", default-features = false }
 prost = "0.12"
 prost-build = "0.12"
 prost-types = "0.12"
+rand = "0.8.5"
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["serde_derive"] }
 serde_json = "1.0"

--- a/crates/proof-of-sql-sdk-local/Cargo.toml
+++ b/crates/proof-of-sql-sdk-local/Cargo.toml
@@ -24,6 +24,7 @@ tonic-build = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+rand = { workspace = true }
 
 [features]
 default = ["native", "prover-client"]

--- a/crates/proof-of-sql-sdk-local/src/lib.rs
+++ b/crates/proof-of-sql-sdk-local/src/lib.rs
@@ -7,6 +7,8 @@ pub mod sxt_chain_runtime;
 mod substrate_query;
 pub use substrate_query::table_ref_to_table_id;
 
+mod uppercase_accessor;
+
 mod prover_query;
 pub use prover_query::{plan_prover_query_dory, PlanProverQueryError, DEFAULT_SCHEMA};
 

--- a/crates/proof-of-sql-sdk-local/src/uppercase_accessor.rs
+++ b/crates/proof-of-sql-sdk-local/src/uppercase_accessor.rs
@@ -1,0 +1,153 @@
+use proof_of_sql::base::{
+    commitment::Commitment,
+    database::{
+        ColumnRef, ColumnType, CommitmentAccessor, MetadataAccessor, SchemaAccessor, TableRef,
+    },
+};
+use sqlparser::ast::Ident;
+
+fn uppercase_ident(ident: Ident) -> Ident {
+    Ident {
+        value: ident.value.to_uppercase(),
+        ..ident
+    }
+}
+
+fn uppercase_table_ref(table_ref: TableRef) -> TableRef {
+    TableRef::from_idents(
+        table_ref.schema_id().cloned().map(uppercase_ident),
+        uppercase_ident(table_ref.table_id().clone()),
+    )
+}
+
+/// Generic wrapper of proof-of-sql `-Accessor` types that coerces to uppercase.
+///
+/// Sxt-chain generally stores identifiers in all uppercase.
+/// The SDK uses accessors in this casing due to using a `QueryCommitments` built from chain data.
+/// So, this wrapper helps bridge the gap between the casing of queries/proof plans to chain data.
+pub struct UppercaseAccessor<'a, A>(pub &'a A);
+
+impl<SA> SchemaAccessor for UppercaseAccessor<'_, SA>
+where
+    SA: SchemaAccessor,
+{
+    fn lookup_column(&self, table_ref: TableRef, column_id: Ident) -> Option<ColumnType> {
+        let ident = uppercase_ident(column_id);
+        self.0.lookup_column(uppercase_table_ref(table_ref), ident)
+    }
+
+    fn lookup_schema(&self, table_ref: TableRef) -> Vec<(Ident, ColumnType)> {
+        self.0
+            .lookup_schema(uppercase_table_ref(table_ref))
+            .into_iter()
+            .map(|(ident, column_type)| {
+                let ident = uppercase_ident(ident);
+                (ident, column_type)
+            })
+            .collect()
+    }
+}
+
+impl<MA> MetadataAccessor for UppercaseAccessor<'_, MA>
+where
+    MA: MetadataAccessor,
+{
+    fn get_length(&self, table_ref: &TableRef) -> usize {
+        let table_ref = uppercase_table_ref(table_ref.clone());
+
+        self.0.get_length(&table_ref)
+    }
+
+    fn get_offset(&self, table_ref: &TableRef) -> usize {
+        let table_ref = uppercase_table_ref(table_ref.clone());
+
+        self.0.get_offset(&table_ref)
+    }
+}
+
+impl<CA, C> CommitmentAccessor<C> for UppercaseAccessor<'_, CA>
+where
+    CA: CommitmentAccessor<C>,
+    C: Commitment,
+{
+    fn get_commitment(&self, column: ColumnRef) -> C {
+        let column = ColumnRef::new(
+            uppercase_table_ref(column.table_ref()),
+            uppercase_ident(column.column_id()),
+            *column.column_type(),
+        );
+
+        self.0.get_commitment(column)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proof_of_sql::{
+        base::{
+            commitment::{QueryCommitments, TableCommitment},
+            database::OwnedColumn,
+        },
+        proof_primitive::dory::{DoryScalar, DynamicDoryCommitment, ProverSetup, PublicParameters},
+    };
+
+    #[test]
+    fn we_can_get_uppercase_items_from_lowercase() {
+        let public_parameters = PublicParameters::test_rand(2, &mut rand::thread_rng());
+        let setup = ProverSetup::from(&public_parameters);
+
+        let lowercase_col = Ident::new("col");
+        let uppercase_col = Ident::new("COL");
+
+        let lowercase_table_ref: TableRef = "schema.table".parse().unwrap();
+        let uppercase_table_ref: TableRef = "SCHEMA.TABLE".parse().unwrap();
+        let lowercase_column_ref = ColumnRef::new(
+            lowercase_table_ref.clone(),
+            lowercase_col.clone(),
+            ColumnType::Boolean,
+        );
+
+        let commitment = TableCommitment::try_from_columns_with_offset(
+            [(
+                &uppercase_col,
+                &OwnedColumn::<DoryScalar>::Boolean(vec![false]),
+            )],
+            0,
+            &&setup,
+        )
+        .unwrap();
+
+        let accessor = QueryCommitments::<DynamicDoryCommitment>::from_iter([(
+            uppercase_table_ref,
+            commitment.clone(),
+        )]);
+
+        assert_eq!(
+            accessor.lookup_column(lowercase_table_ref.clone(), lowercase_col.clone()),
+            None
+        );
+        assert_eq!(
+            UppercaseAccessor(&accessor).lookup_column(lowercase_table_ref.clone(), lowercase_col),
+            Some(ColumnType::Boolean)
+        );
+
+        assert_eq!(
+            UppercaseAccessor(&accessor).lookup_schema(lowercase_table_ref.clone()),
+            vec![(uppercase_col.clone(), ColumnType::Boolean)]
+        );
+
+        assert_eq!(
+            UppercaseAccessor(&accessor).get_length(&lowercase_table_ref),
+            1
+        );
+        assert_eq!(
+            UppercaseAccessor(&accessor).get_offset(&lowercase_table_ref),
+            0
+        );
+        assert_eq!(
+            UppercaseAccessor(&accessor).get_commitment(lowercase_column_ref),
+            commitment.column_commitments().commitments()[0]
+        );
+    }
+}

--- a/crates/proof-of-sql-sdk-local/src/verify.rs
+++ b/crates/proof-of-sql-sdk-local/src/verify.rs
@@ -1,4 +1,4 @@
-use crate::prover::ProverResponse;
+use crate::{prover::ProverResponse, uppercase_accessor::UppercaseAccessor};
 use proof_of_sql::{
     base::{
         commitment::CommitmentEvaluationProof,
@@ -39,6 +39,7 @@ pub fn verify_prover_response<'de, 's, CP: CommitmentEvaluationProof + Deseriali
     accessor: &impl CommitmentAccessor<CP::Commitment>,
     verifier_setup: &CP::VerifierPublicSetup<'s>,
 ) -> Result<OwnedTable<CP::Scalar>, VerifyProverResponseError> {
+    let accessor = UppercaseAccessor(accessor);
     let proof: QueryProof<CP> = bincode::serde::borrow_decode_from_slice(
         &prover_response.proof,
         bincode::config::legacy()
@@ -57,7 +58,7 @@ pub fn verify_prover_response<'de, 's, CP: CommitmentEvaluationProof + Deseriali
     // Verify the proof
     proof.verify(
         query_expr.proof_expr(),
-        accessor,
+        &accessor,
         result.clone(),
         verifier_setup,
     )?;


### PR DESCRIPTION
# Rationale for this change
It turns out, after we get a successful response from the prover, we still need the QueryCommitments to act as a MetadataAccessor and CommitmentAccessor. However, the issue still remains that the query/proof plan will not necessarily match the all-uppercase chain data that the query commitments was built from.

# What changes are included in this PR?
This change makes UppercaseAccessor implement more proof-of-sql accessor traits. It also just treats it with a higher level concern in general, giving it its own module with documentation and tests.

# Are these changes tested?
Yes.
