### PR TITLE
ci: DC-171 set permissions in workflow instead of using GH_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,16 +7,16 @@ on:
 jobs:
   release:
     name: Run Release Manager
-
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_TOKEN }}
-          ref: ${{ github.head_ref }}
           # Make sure the value of GITHUB_TOKEN will not be persisted in repo's config
           persist-credentials: false
           # Pull all previous tags
@@ -27,7 +27,6 @@ jobs:
         id: conventional-changelog
         uses: TriPSs/conventional-changelog-action@v5
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
           skip-git-pull: true
           skip-version-file: true
           git-push: false
@@ -53,7 +52,6 @@ jobs:
         uses: ad-m/github-push-action@master
         id: push
         with:
-          github_token: ${{ secrets.GH_TOKEN }}
           branch: ${{ github.ref }}
 
       - name: Create Release
@@ -61,7 +59,6 @@ jobs:
         with:
           tag: ${{ steps.conventional-changelog.outputs.tag }}
           body: ${{ steps.conventional-changelog.outputs.changelog }}
-          token: ${{ secrets.GH_TOKEN }}
           makeLatest: true
 
       - name: Install stable toolchain


### PR DESCRIPTION
The GH_TOKEN should not be needed because that grants access to other repositories. This workflow only needs write access to itself, so we can configure permissions in the job itself and remove the overrides for token in different steps.
