### PR TITLE
feat: set default plan display to be the evm plan

### DIFF
--- a/src/produce_plan_subcommand.rs
+++ b/src/produce_plan_subcommand.rs
@@ -27,7 +27,7 @@ pub struct ProducePlanArgs {
     #[arg(long, default_value = "false")]
     pub debug_plan: bool,
     /// Display the result as serialized hex code of the evm plan
-    #[arg(long, default_value = "false")]
+    #[arg(long, default_value = "true")]
     pub evm: bool,
 }
 


### PR DESCRIPTION
# Rationale for this change

The default plan display should be an EVM compatible plan.