### PR TITLE
fix!: include verifier setups in the compiled binary

### DIFF
--- a/examples/count-ethereum-core/main.rs
+++ b/examples/count-ethereum-core/main.rs
@@ -115,7 +115,7 @@ async fn main() {
         env::var("AUTH_ROOT_URL").unwrap_or("https://proxy.api.makeinfinite.dev".to_string()),
         env::var("SUBSTRATE_NODE_URL").unwrap_or("wss://rpc.testnet.sxt.network".to_string()),
         env::var("SXT_API_KEY").expect("SXT_API_KEY is required"),
-        env::var("VERIFIER_SETUP").unwrap_or("verifier_setup.bin".to_string()),
+        env::var("VERIFIER_SETUP").ok(),
     ));
 
     let current_counts: IndexMap<String, i64> = futures::stream::iter(ETHEREUM_CORE_TABLES)

--- a/src/base/commitment_scheme.rs
+++ b/src/base/commitment_scheme.rs
@@ -28,6 +28,17 @@ pub enum CommitmentScheme {
     HyperKzg,
 }
 
+// Default verifier setups for different commitment schemes.
+const DYNAMIC_DORY_VERIFIER_SETUP_BYTES: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/verifier_setups/dynamic-dory.bin"
+));
+#[cfg(feature = "hyperkzg")]
+const HYPER_KZG_VERIFIER_SETUP_BYTES: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/verifier_setups/hyper-kzg.bin"
+));
+
 /// Convert a `CommitmentScheme` to a `prover::CommitmentScheme`.
 impl From<CommitmentScheme> for prover::CommitmentScheme {
     fn from(scheme: CommitmentScheme) -> Self {
@@ -67,6 +78,9 @@ pub trait CommitmentEvaluationProofId:
     /// The [`CommitmentScheme`] associated with this commitment type.
     const COMMITMENT_SCHEME: CommitmentScheme;
 
+    /// The default verifier setup for this commitment type in bytes.
+    const DEFAULT_VERIFIER_SETUP_BYTES: &'static [u8];
+
     /// Error type for deserialization failures.
     type DeserializationError: core::error::Error;
 
@@ -89,6 +103,7 @@ pub trait CommitmentEvaluationProofId:
 #[cfg(feature = "hyperkzg")]
 impl CommitmentEvaluationProofId for HyperKZGCommitmentEvaluationProof {
     const COMMITMENT_SCHEME: CommitmentScheme = CommitmentScheme::HyperKzg;
+    const DEFAULT_VERIFIER_SETUP_BYTES: &'static [u8] = HYPER_KZG_VERIFIER_SETUP_BYTES;
     type DeserializationError = bincode::error::DecodeError;
     type AssociatedProofPlan = EVMProofPlan;
 
@@ -113,6 +128,7 @@ impl CommitmentEvaluationProofId for HyperKZGCommitmentEvaluationProof {
 
 impl CommitmentEvaluationProofId for DynamicDoryEvaluationProof {
     const COMMITMENT_SCHEME: CommitmentScheme = CommitmentScheme::DynamicDory;
+    const DEFAULT_VERIFIER_SETUP_BYTES: &'static [u8] = DYNAMIC_DORY_VERIFIER_SETUP_BYTES;
     type DeserializationError = ark_serialize::SerializationError;
     type AssociatedProofPlan = DynProofPlan;
 

--- a/src/native/client.rs
+++ b/src/native/client.rs
@@ -36,8 +36,8 @@ pub struct SxTClient {
     /// if you do not have one.
     pub sxt_api_key: String,
 
-    /// Path to the verifier setup binary file
-    pub verifier_setup: String,
+    /// Path to the verifier setup binary file. If `None`, the default verifier setup is used.
+    pub verifier_setup: Option<String>,
 }
 
 impl SxTClient {
@@ -47,7 +47,7 @@ impl SxTClient {
         auth_root_url: String,
         substrate_node_url: String,
         sxt_api_key: String,
-        verifier_setup: String,
+        verifier_setup: Option<String>,
     ) -> Self {
         Self {
             prover_root_url,
@@ -81,8 +81,11 @@ impl SxTClient {
             .collect::<Vec<_>>();
 
         // Load verifier setup
-        let verifier_setup =
-            CPI::deserialize_verifier_setup(&std::fs::read(&self.verifier_setup)?, bump)?;
+        let verifier_setup_bytes = match &self.verifier_setup {
+            Some(path) => &std::fs::read(path)?,
+            None => CPI::DEFAULT_VERIFIER_SETUP_BYTES,
+        };
+        let verifier_setup = CPI::deserialize_verifier_setup(verifier_setup_bytes, bump)?;
         // Accessor setup
         let accessor = query_commitments::<<SxtConfig as Config>::Hash, CPI>(
             &table_refs,

--- a/src/query_and_verify.rs
+++ b/src/query_and_verify.rs
@@ -67,30 +67,23 @@ pub struct QueryAndVerifySdkArgs {
     /// Path to the verifier setup binary file
     ///
     /// Specifies the path to the verifier setup binary file required for verification.
-    /// If commitment_scheme is HyperKZG, the default is "verifier_setups/hyper-kzg.bin".
-    /// If commitment_scheme is DynamicDory, the default is "verifier_setups/dynamic-dory.bin".
     #[arg(
         long,
         value_name = "VERIFIER_SETUP",
-        help = "Path to the verifier setup file. Defaults to verifier_setups/hyper-kzg.bin for HyperKZG or verifier_setups/dynamic-dory.bin for DynamicDory."
+        help = "Path to the verifier setup file. If not provided, defaults to the appropriate verifier setup for the selected commitment scheme."
     )]
     pub verifier_setup: Option<String>,
 }
 
 impl From<&QueryAndVerifySdkArgs> for (SxTClient, CommitmentScheme) {
     fn from(args: &QueryAndVerifySdkArgs) -> Self {
-        let verifier_setup = match (args.verifier_setup.as_deref(), args.commitment_scheme) {
-            (Some(path), _) => path.to_string(),
-            (None, CommitmentScheme::HyperKzg) => "verifier_setups/hyper-kzg.bin".to_string(),
-            (None, CommitmentScheme::DynamicDory) => "verifier_setups/dynamic-dory.bin".to_string(),
-        };
         (
             SxTClient::new(
                 args.prover_root_url.clone(),
                 args.auth_root_url.clone(),
                 args.substrate_node_url.clone(),
                 args.sxt_api_key.clone(),
-                verifier_setup,
+                args.verifier_setup.clone(),
             ),
             args.commitment_scheme,
         )


### PR DESCRIPTION
# Rationale for this change
Currently we can not install from git easily and still use the SDK because the default verifier setup files depend on the crate file structure. Now the files have been included as binaries and will be the default options.