### PR TITLE
feat: add JSON-RPC calls for getting attestations and commitments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3524,6 +3524,8 @@ dependencies = [
  "jsonrpsee-core 0.22.5",
  "jsonrpsee-http-client",
  "jsonrpsee-types 0.22.5",
+ "jsonrpsee-wasm-client 0.22.5",
+ "jsonrpsee-ws-client 0.22.5",
 ]
 
 [[package]]
@@ -3534,8 +3536,8 @@ checksum = "62b089779ad7f80768693755a031cc14a7766aba707cbe886674e3f79e9b7e47"
 dependencies = [
  "jsonrpsee-core 0.23.2",
  "jsonrpsee-types 0.23.2",
- "jsonrpsee-wasm-client",
- "jsonrpsee-ws-client",
+ "jsonrpsee-wasm-client 0.23.2",
+ "jsonrpsee-ws-client 0.23.2",
 ]
 
 [[package]]
@@ -3559,6 +3561,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3681,6 +3684,17 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f448d8eacd945cc17b6c0b42c361531ca36a962ee186342a97cdb8fca679cd77"
+dependencies = [
+ "jsonrpsee-client-transport 0.22.5",
+ "jsonrpsee-core 0.22.5",
+ "jsonrpsee-types 0.22.5",
+]
+
+[[package]]
+name = "jsonrpsee-wasm-client"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4727ac037f834c6f04c0912cada7532dbddb54e92fbc64e33d6cb8c24af313c9"
@@ -3688,6 +3702,19 @@ dependencies = [
  "jsonrpsee-client-transport 0.23.2",
  "jsonrpsee-core 0.23.2",
  "jsonrpsee-types 0.23.2",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b9db2dfd5bb1194b0ce921504df9ceae210a345bc2f6c5a61432089bbab070"
+dependencies = [
+ "http 0.2.12",
+ "jsonrpsee-client-transport 0.22.5",
+ "jsonrpsee-core 0.22.5",
+ "jsonrpsee-types 0.22.5",
+ "url",
 ]
 
 [[package]]
@@ -6421,6 +6448,7 @@ dependencies = [
  "hex",
  "indexmap 2.10.0",
  "itertools 0.13.0",
+ "jsonrpsee 0.22.5",
  "k256",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ env_logger = "0.11.5"
 futures = { version = "0.3.31"}
 gloo-utils = { version = "0.2.0" }
 hex = { version = "0.4.3", default-features = false, features = ["serde"] }
+jsonrpsee = { version = "0.22.5", default-features = false, features = ["client"], optional = true }
 lazy_static = { version = "1.5.0" }
 log = "0.4.22"
 indexmap = "2.8.0"
@@ -58,7 +59,7 @@ default = ["native", "prover-client", "hyperkzg"]
 prover-client = ["tonic/transport"]
 # Do not use the `native` feature unless you are building for the native environment.
 # It can not be used with the `wasm` feature.
-native = ["subxt/native", "proof-of-sql/std", "sqlparser/std", "tokio/rt-multi-thread"]
+native = ["subxt/native", "proof-of-sql/std", "sqlparser/std", "tokio/rt-multi-thread", "jsonrpsee"]
 # Currently the `hyperkzg` and `wasm` features are incompatible.
 hyperkzg = ["proof-of-sql/hyperkzg_proof", "nova-snark"]
 

--- a/src/base/commitment_scheme.rs
+++ b/src/base/commitment_scheme.rs
@@ -29,6 +29,16 @@ pub enum CommitmentScheme {
     HyperKzg,
 }
 
+impl core::fmt::Display for CommitmentScheme {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            CommitmentScheme::DynamicDory => "DynamicDory",
+            #[cfg(feature = "hyperkzg")]
+            CommitmentScheme::HyperKzg => "HyperKzg",
+        })
+    }
+}
+
 // Default verifier setups for different commitment schemes.
 const DYNAMIC_DORY_VERIFIER_SETUP_BYTES: &[u8] = include_bytes!(concat!(
     env!("CARGO_MANIFEST_DIR"),

--- a/src/base/mod.rs
+++ b/src/base/mod.rs
@@ -33,3 +33,4 @@ pub mod prover {
 
 /// types for verifying attestations
 pub mod attestation;
+pub mod verifiable_commitment;

--- a/src/base/verifiable_commitment.rs
+++ b/src/base/verifiable_commitment.rs
@@ -1,0 +1,26 @@
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use sp_core::Bytes;
+use subxt::utils::H256;
+
+/// Serialization format for a Commitment and its attestation merkle proof.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifiableCommitment {
+    /// The commitment bytes.
+    pub commitment: Bytes,
+    /// The merkle proof.
+    ///
+    /// The Strings here are always hex encoded bytes.
+    pub merkle_proof: Vec<String>,
+}
+
+/// Serialization format for an api response returning verifiable commitments.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifiableCommitmentsResponse {
+    /// The verifiable commitments.
+    pub verifiable_commitments: IndexMap<String, VerifiableCommitment>,
+    /// The block hash that this query accessed storage with.
+    pub at: H256,
+}

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -4,6 +4,9 @@ pub use auth::get_access_token;
 mod plan;
 pub use plan::produce_plan;
 
+mod rpc;
+pub use rpc::{fetch_attestation, fetch_verified_commitments};
+
 mod client;
 pub use client::SxTClient;
 

--- a/src/native/rpc.rs
+++ b/src/native/rpc.rs
@@ -1,0 +1,72 @@
+use crate::base::{
+    attestation::{Attestation, AttestationsResponse},
+    verifiable_commitment::VerifiableCommitmentsResponse,
+    CommitmentScheme,
+};
+use jsonrpsee::{
+    core::{client::ClientT, params::ArrayParams, rpc_params, ClientError},
+    ws_client::WsClient,
+};
+use subxt::utils::H256;
+
+/// Fetch attestations for a block hash
+async fn fetch_attestation_for_block(
+    client: &WsClient,
+    block_hash: H256,
+) -> Result<Vec<Attestation>, ClientError> {
+    let response = client
+        .request::<AttestationsResponse, ArrayParams>(
+            "attestation_v1_getByBlockHash",
+            rpc_params![format!("{block_hash:#x}")],
+        )
+        .await?;
+
+    Ok(response.attestations)
+}
+
+/// Fetch the recent block with the most attestations
+async fn fetch_best_recent_attestation(
+    client: &WsClient,
+) -> Result<(H256, Vec<Attestation>), ClientError> {
+    let attestation_response: AttestationsResponse = client
+        .request("attestation_v1_bestRecentAttestations", rpc_params![])
+        .await?;
+    Ok((
+        attestation_response.attestations_for,
+        attestation_response.attestations,
+    ))
+}
+
+/// Fetch attestation
+///
+/// If a block hash is provided, fetch attestations for that block. Otherwise, fetch the most recent attestations
+/// with the block hash.
+pub async fn fetch_attestation(
+    client: &WsClient,
+    block_hash: Option<H256>,
+) -> Result<(H256, Vec<Attestation>), ClientError> {
+    match block_hash {
+        Some(hash) => Ok((hash, fetch_attestation_for_block(client, hash).await?)),
+        None => fetch_best_recent_attestation(client).await,
+    }
+}
+
+/// Fetch verified commitments for a given `ProofPlan` and `CommitmentScheme` at a given block.
+pub async fn fetch_verified_commitments(
+    client: &WsClient,
+    serialized_proof_plan: String,
+    commitment_scheme: CommitmentScheme,
+    block_hash: H256,
+) -> Result<VerifiableCommitmentsResponse, ClientError> {
+    let response = client
+        .request::<VerifiableCommitmentsResponse, ArrayParams>(
+            "commitments_v1_verifiableCommitmentsForProofPlan",
+            rpc_params![
+                serialized_proof_plan,
+                commitment_scheme.to_string(),
+                format!("{block_hash:#x}")
+            ],
+        )
+        .await?;
+    Ok(response)
+}


### PR DESCRIPTION
# Rationale for this change
We need to redo attestation.
# What are the changes?
- add `fetch_attestation` which uses attestation at a given block hash if there is one or the best most recent one if there isn't
- add `fetch_verified_commitments` which fetches verified commitments
