### PR TITLE
refactor: use standard binary serde

### DIFF
--- a/src/base/prover_query.rs
+++ b/src/base/prover_query.rs
@@ -9,7 +9,10 @@ use proof_of_sql::proof_primitive::hyperkzg::{
     HyperKZGCommitment, HyperKZGCommitmentEvaluationProof,
 };
 use proof_of_sql::{
-    base::commitment::{CommitmentEvaluationProof, QueryCommitments},
+    base::{
+        commitment::{CommitmentEvaluationProof, QueryCommitments},
+        try_standard_binary_serialization,
+    },
     proof_primitive::dory::{DynamicDoryCommitment, DynamicDoryEvaluationProof},
     sql::proof_plans::DynProofPlan,
 };
@@ -53,11 +56,8 @@ pub fn plan_prover_query<CPI: CommitmentEvaluationProofId>(
     let mut config_options = ConfigOptions::default();
     config_options.sql_parser.enable_ident_normalization = false;
     let proof_plan = sql_to_proof_plans(&[query.clone()], accessor, &config_options)?[0].clone();
-    let bincode_config = bincode::config::legacy()
-        .with_fixed_int_encoding()
-        .with_big_endian();
     let serialized_proof_plan =
-        bincode::serde::encode_to_vec(CPI::associated_proof_plan(&proof_plan), bincode_config)?;
+        try_standard_binary_serialization(CPI::associated_proof_plan(&proof_plan))?;
 
     let query_context = commitments
         .iter()

--- a/src/base/verifiable_commitment.rs
+++ b/src/base/verifiable_commitment.rs
@@ -7,6 +7,7 @@ use indexmap::IndexMap;
 use proof_of_sql::base::{
     commitment::{CommitmentEvaluationProof, QueryCommitments, TableCommitment},
     database::TableRef,
+    try_standard_binary_deserialization,
 };
 use serde::{Deserialize, Serialize};
 use sp_core::Bytes;
@@ -82,11 +83,8 @@ pub fn extract_query_commitments_from_verifiable_commitments<CPI: CommitmentEval
                     let table_ref = TableRef::try_from(table_id.as_str())?;
                     let table_commitment: TableCommitment<
                         <CPI as CommitmentEvaluationProof>::Commitment,
-                    > = bincode::serde::decode_from_slice(
+                    > = try_standard_binary_deserialization(
                         &verified_commitment.commitment, // or the correct bytes field
-                        bincode::config::legacy()
-                            .with_fixed_int_encoding()
-                            .with_big_endian(),
                     )?
                     .0;
                     Ok((table_ref, table_commitment))

--- a/src/native/substrate.rs
+++ b/src/native/substrate.rs
@@ -16,6 +16,7 @@ use itertools::Itertools;
 use proof_of_sql::base::{
     commitment::{CommitmentEvaluationProof, QueryCommitments, TableCommitment},
     database::TableRef,
+    try_standard_binary_deserialization,
 };
 use snafu::{ResultExt, Snafu};
 use subxt::{blocks::BlockRef, Config, OnlineClient, PolkadotConfig};
@@ -60,13 +61,8 @@ where
                 .fetch(&commitments_query)
                 .await?
                 .ok_or("Commitment not found")?;
-            let table_commitments = bincode::serde::decode_from_slice(
-                &table_commitment_bytes.data.0,
-                bincode::config::legacy()
-                    .with_fixed_int_encoding()
-                    .with_big_endian(),
-            )?
-            .0;
+            let table_commitments =
+                try_standard_binary_deserialization(&table_commitment_bytes.data.0)?.0;
             Ok::<
                 (
                     TableRef,

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -13,6 +13,7 @@ use proof_of_sql::{
     base::{
         commitment::{Commitment, QueryCommitments},
         database::TableRef,
+        try_standard_binary_deserialization,
     },
     proof_primitive::dory::{DynamicDoryEvaluationProof, VerifierSetup},
 };
@@ -108,14 +109,12 @@ where
                 )
                 .map_err(|e| format!("failed to decode table commitment bytes: {e}"))?;
 
-                let table_commitment = bincode::serde::decode_from_slice(
-                    &table_commitment_bytes.data.0,
-                    bincode::config::legacy()
-                        .with_fixed_int_encoding()
-                        .with_big_endian(),
-                )
-                .map_err(|e| format!("failed to deserialize table commitment using bincode: {e}"))?
-                .0;
+                let table_commitment =
+                    try_standard_binary_deserialization(&table_commitment_bytes.data.0)
+                        .map_err(|e| {
+                            format!("failed to deserialize table commitment using bincode: {e}")
+                        })?
+                        .0;
                 Ok((table_ref, table_commitment))
             },
         )


### PR DESCRIPTION
# Rationale for this change

We are using a lot of duplicate serialization logic in the sdk.

# What changes are included in this PR?

Using the utility methods found in proof of sql.

# Are these changes tested?
No
