### PR TITLE
fix: remove `/v1/prove`

### DIFF
--- a/src/native/client.rs
+++ b/src/native/client.rs
@@ -23,7 +23,7 @@ use url::Url;
 #[derive(Debug, Clone)]
 pub struct SxTClient {
     /// Root URL for the Prover service
-    pub prover_root_url: Url,
+    pub prover_url: Url,
 
     /// Root URL for the Auth service
     pub auth_root_url: Url,
@@ -44,14 +44,14 @@ pub struct SxTClient {
 impl SxTClient {
     /// Create a new SxT client
     pub fn new(
-        prover_root_url: Url,
+        prover_url: Url,
         auth_root_url: Url,
         substrate_node_url: Url,
         sxt_api_key: String,
         verifier_setup: Option<String>,
     ) -> Self {
         Self {
-            prover_root_url,
+            prover_url,
             auth_root_url,
             substrate_node_url,
             sxt_api_key,
@@ -100,7 +100,7 @@ impl SxTClient {
         let client = Client::new();
         let access_token = get_access_token(&self.sxt_api_key, self.auth_root_url.as_str()).await?;
         let response = client
-            .post(self.prover_root_url.join("v1/prove")?)
+            .post(self.prover_url.clone())
             .bearer_auth(&access_token)
             .json(&prover_query)
             .send()

--- a/src/query_and_verify.rs
+++ b/src/query_and_verify.rs
@@ -13,17 +13,17 @@ use url::Url;
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
 pub struct QueryAndVerifySdkArgs {
-    /// Root URL for the Prover service
+    /// URL for the Prover service
     ///
     /// This URL is used for interacting with the prover service.
-    /// Can be set via PROVER_ROOT_URL environment variable.
+    /// Can be set via PROVER_URL environment variable.
     #[arg(
         long,
-        value_name = "PROVER_ROOT_URL",
+        value_name = "PROVER_URL",
         default_value = "https://api.makeinfinite.dev",
-        env = "PROVER_ROOT_URL"
+        env = "PROVER_URL"
     )]
-    pub prover_root_url: Url,
+    pub prover_url: Url,
 
     /// Root URL for the Auth service
     ///
@@ -92,7 +92,7 @@ impl From<&QueryAndVerifySdkArgs> for (SxTClient, CommitmentScheme) {
     fn from(args: &QueryAndVerifySdkArgs) -> Self {
         (
             SxTClient::new(
-                args.prover_root_url.clone(),
+                args.prover_url.clone(),
                 args.auth_root_url.clone(),
                 args.substrate_node_url.clone(),
                 args.sxt_api_key.clone(),


### PR DESCRIPTION
# Rationale for this change
Rename `prover_root_url` to `prover_url` and remove `/v1/prove`