### PR TITLE
feat: ignore all `**/*.env` files and remove unnecessary `#[allow(dead_code)]` from `native/auth.rs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.env
+**/*.env
 **/*.log
 **/*.json
 **/node_modules

--- a/src/native/auth.rs
+++ b/src/native/auth.rs
@@ -3,7 +3,6 @@ use reqwest::Client;
 ///
 /// To obtain an API key please visit [Space and Time Studio](https://app.spaceandtime.ai/) and create an account.
 /// See [Get API Key Using Space and Time Studio](https://docs.spaceandtime.io/docs/using-studioapi-key) for more information.
-#[allow(dead_code)]
 pub async fn get_access_token(
     apikey: &str,
     url: &str,


### PR DESCRIPTION
# Rationale for this change
1. Ignore more `.env` files since testnet and mainnet have different config.
2. That one func is actually used.