### PR TITLE
fix: replace `String` with `Url` for urls in client and CLI

### DIFF
--- a/examples/count-ethereum-core/main.rs
+++ b/examples/count-ethereum-core/main.rs
@@ -9,6 +9,7 @@ use sxt_proof_of_sql_sdk::{
     base::{CommitmentScheme, DynOwnedTable},
     native::SxTClient,
 };
+use url::Url;
 
 const ETHEREUM_CORE_COUNTS_FILE: &str = "ethereum-core-counts.json";
 
@@ -111,9 +112,18 @@ async fn main() {
         _ => panic!("Unsupported commitment scheme"),
     };
     let client = Arc::new(SxTClient::new(
-        env::var("PROVER_ROOT_URL").unwrap_or("https://api.makeinfinite.dev".to_string()),
-        env::var("AUTH_ROOT_URL").unwrap_or("https://proxy.api.makeinfinite.dev".to_string()),
-        env::var("SUBSTRATE_NODE_URL").unwrap_or("wss://rpc.testnet.sxt.network".to_string()),
+        Url::parse(
+            &env::var("PROVER_ROOT_URL").unwrap_or("https://api.makeinfinite.dev".to_string()),
+        )
+        .unwrap(),
+        Url::parse(
+            &env::var("AUTH_ROOT_URL").unwrap_or("https://proxy.api.makeinfinite.dev".to_string()),
+        )
+        .unwrap(),
+        Url::parse(
+            &env::var("SUBSTRATE_NODE_URL").unwrap_or("wss://rpc.testnet.sxt.network".to_string()),
+        )
+        .unwrap(),
         env::var("SXT_API_KEY").expect("SXT_API_KEY is required"),
         env::var("VERIFIER_SETUP").ok(),
     ));

--- a/src/args.rs
+++ b/src/args.rs
@@ -19,6 +19,6 @@ pub struct ProofOfSqlSdkArgs {
 
 #[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
 pub enum ProofOfSqlSdkSubcommands {
-    QueryAndVerify(QueryAndVerifySdkArgs),
-    ProducePlan(ProducePlanArgs),
+    QueryAndVerify(Box<QueryAndVerifySdkArgs>),
+    ProducePlan(Box<ProducePlanArgs>),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn core::error::Error>> {
     // Parse command-line arguments
     let sdk_args = ProofOfSqlSdkArgs::parse();
     match sdk_args.command {
-        ProofOfSqlSdkSubcommands::QueryAndVerify(args) => query_and_verify(args).await,
-        ProofOfSqlSdkSubcommands::ProducePlan(args) => produce_plan_command(args).await,
+        ProofOfSqlSdkSubcommands::QueryAndVerify(args) => query_and_verify(*args).await,
+        ProofOfSqlSdkSubcommands::ProducePlan(args) => produce_plan_command(*args).await,
     }
 }

--- a/src/native/plan.rs
+++ b/src/native/plan.rs
@@ -11,7 +11,7 @@ use subxt::Config;
 ///
 /// We use dynamic dory here because proof plans are not dependent on the commitment scheme
 pub async fn produce_plan(
-    substrate_node_url: String,
+    substrate_node_url: &str,
     query: &str,
     block_ref: Option<<SxtConfig as Config>::Hash>,
 ) -> Result<DynProofPlan, Box<dyn core::error::Error>> {
@@ -23,7 +23,7 @@ pub async fn produce_plan(
         .collect::<Vec<_>>();
     let accessor = query_commitments::<<SxtConfig as Config>::Hash, DynamicDoryEvaluationProof>(
         &table_refs,
-        &substrate_node_url,
+        substrate_node_url,
         block_ref,
     )
     .await?;

--- a/src/produce_plan_subcommand.rs
+++ b/src/produce_plan_subcommand.rs
@@ -2,6 +2,7 @@ use crate::native::produce_plan;
 use clap::Parser;
 use proof_of_sql::{base::try_standard_binary_serialization, sql::evm_proof_plan::EVMProofPlan};
 use subxt::utils::H256;
+use url::Url;
 
 #[derive(Parser, Debug, Clone, PartialEq, Eq)]
 #[command(
@@ -16,7 +17,7 @@ pub struct ProducePlanArgs {
         default_value = "wss://rpc.testnet.sxt.network",
         env = "SUBSTRATE_NODE_URL"
     )]
-    pub substrate_node_url: String,
+    pub substrate_node_url: Url,
     /// SQL query to retrieve a plan for
     #[arg(short, long)]
     pub query: String,
@@ -35,7 +36,12 @@ pub async fn produce_plan_command(
     args: ProducePlanArgs,
 ) -> Result<(), Box<dyn core::error::Error>> {
     // Retrieve the proof plan
-    let plan = produce_plan(args.substrate_node_url, &args.query, args.block_hash).await?;
+    let plan = produce_plan(
+        args.substrate_node_url.as_str(),
+        &args.query,
+        args.block_hash,
+    )
+    .await?;
 
     if args.debug_plan {
         println!("{:?}", plan);

--- a/src/query_and_verify.rs
+++ b/src/query_and_verify.rs
@@ -9,6 +9,7 @@ use datafusion::arrow::{
 };
 use std::{path::PathBuf, sync::Arc};
 use subxt::utils::H256;
+use url::Url;
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
 pub struct QueryAndVerifySdkArgs {
@@ -22,7 +23,7 @@ pub struct QueryAndVerifySdkArgs {
         default_value = "https://api.makeinfinite.dev",
         env = "PROVER_ROOT_URL"
     )]
-    pub prover_root_url: String,
+    pub prover_root_url: Url,
 
     /// Root URL for the Auth service
     ///
@@ -34,7 +35,7 @@ pub struct QueryAndVerifySdkArgs {
         default_value = "https://proxy.api.makeinfinite.dev",
         env = "AUTH_ROOT_URL"
     )]
-    pub auth_root_url: String,
+    pub auth_root_url: Url,
 
     /// URL for the Substrate node service
     ///
@@ -46,7 +47,7 @@ pub struct QueryAndVerifySdkArgs {
         default_value = "wss://rpc.testnet.sxt.network",
         env = "SUBSTRATE_NODE_URL"
     )]
-    pub substrate_node_url: String,
+    pub substrate_node_url: Url,
 
     /// API Key for Space and Time (SxT) services
     ///


### PR DESCRIPTION
# Rationale for this change
Because `Url`s are more restrictive hence better types to use here.