### PR TITLE
refactor: use evm proof plan

### DIFF
--- a/src/base/verify.rs
+++ b/src/base/verify.rs
@@ -8,8 +8,8 @@ use proof_of_sql::{
         try_standard_binary_deserialization,
     },
     sql::{
+        evm_proof_plan::EVMProofPlan,
         proof::{QueryError, QueryProof},
-        proof_plans::DynProofPlan,
     },
 };
 use snafu::Snafu;
@@ -37,7 +37,7 @@ impl From<bincode::error::DecodeError> for VerifyProverResponseError {
 /// Verify a response from the prover service against the provided commitment accessor.
 pub fn verify_prover_response<CPI: CommitmentEvaluationProofId>(
     prover_response: &ProverResponse,
-    proof_plan: &DynProofPlan,
+    proof_plan: &EVMProofPlan,
     params: &[LiteralValue],
     accessor: &impl CommitmentAccessor<<CPI as CommitmentEvaluationProof>::Commitment>,
     verifier_setup: &<CPI as CommitmentEvaluationProof>::VerifierPublicSetup<'_>,
@@ -49,7 +49,7 @@ pub fn verify_prover_response<CPI: CommitmentEvaluationProofId>(
 
     // Verify the proof
     proof.verify(
-        &CPI::associated_proof_plan(proof_plan),
+        proof_plan,
         &accessor,
         result.clone(),
         verifier_setup,

--- a/src/native/client.rs
+++ b/src/native/client.rs
@@ -12,6 +12,7 @@ use proof_of_sql::proof_primitive::hyperkzg::HyperKZGCommitmentEvaluationProof;
 use proof_of_sql::{
     base::{commitment::CommitmentEvaluationProof, database::OwnedTable},
     proof_primitive::dory::DynamicDoryEvaluationProof,
+    sql::evm_proof_plan::EVMProofPlan,
 };
 use proof_of_sql_planner::get_table_refs_from_statement;
 use reqwest::Client;
@@ -127,7 +128,7 @@ impl SxTClient {
 
         let verified_table_result = verify_prover_response::<CPI>(
             &prover_response,
-            &proof_plan,
+            &EVMProofPlan::new(proof_plan),
             &[],
             &accessor,
             &verifier_setup,


### PR DESCRIPTION
# Rationale for this change

We only want to be using the `EVMProofPlan`, not the `DynProofPlan`.

# What changes are included in this PR?

Removing use of `DynProofPlan`.

# Are these changes tested?
There are some manual tests we can run.
